### PR TITLE
create fixed VHD format disk

### DIFF
--- a/alpinehv.json
+++ b/alpinehv.json
@@ -7,6 +7,7 @@
             "iso_checksum_type": "sha256",
             "disk_size": "512",
             "skip_compaction": "true",
+            "use_fixed_vhd_format": "true",
             "communicator": "ssh",
             "ssh_username": "root",
             "ssh_password": "alpine",


### PR DESCRIPTION
according to 
https://www.packer.io/docs/builders/hyperv-iso.html#use_fixed_vhd_format
this creates the boot disk on the virtual machine as a fixed VHD format disk

You don't need to run
convert.ps1
afterwards