### PR TITLE
Fixed alpinehv.json on Windows (Powershell)

### DIFF
--- a/alpinehv.json
+++ b/alpinehv.json
@@ -13,7 +13,7 @@
             "http_directory": "http",
             "http_port_min": "8080",
             "http_port_max": "8080",
-            "switch_name": "Default Switch",
+            "switch_name": "\"Default Switch\"",
             "boot_wait": "10s",
             "boot_command": [
                 "root<enter><wait>",


### PR DESCRIPTION
I realized this didn't run on Windows 10 (build 17134.590), and the issue was related to launching a command without double quotes:

==> hyperv-iso: + ... yStartupBytes 1073741824 -VHDPath $vhdPath -SwitchName Default Switch

should have been:

==> hyperv-iso: + ... yStartupBytes 1073741824 -VHDPath $vhdPath -SwitchName "Default Switch"

So I modified the json from:

"switch_name": "Default Switch",

to:
"switch_name": "\"Default Switch\"",

haven't tested this on linux though.